### PR TITLE
fix: Update GLTF model source

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,7 +33,7 @@ function init() {
 
     // GLTF Model Loading
     const gltfLoader = new GLTFLoader();
-    const modelUrl = 'https://raw.githubusercontent.com/RSOS-ops/CoryPill-2/7eb893d18a45859db5110cf113a0a94f1cb46bfd/CoryPill_GLTF.glb';
+    const modelUrl = 'https://raw.githubusercontent.com/RSOS-ops/CoryPill-2/9546cba51f73fd15218959e97c78098392a5b75d/CoryPill_StackedText-1.glb';
 
     gltfLoader.load(
         modelUrl,


### PR DESCRIPTION
This commit changes the GLTF model being loaded by the application. The `modelUrl` in `script.js` has been updated to point to: `CoryPill_StackedText-1.glb`
from the RSOS-ops/CoryPill-2 repository.

All existing logic for scaling, centering, camera positioning, and animation will now apply to this new model.