### PR TITLE
feat: Add dynamic fog to the scene

### DIFF
--- a/script.js
+++ b/script.js
@@ -87,6 +87,20 @@ function init() {
             camera.lookAt(worldSphere.center); // Look at the geometric center of the model
 
             console.log('Camera position adjusted for 90% viewport fill.');
+
+            // Add Fog
+            const fogColor = 0x000000; // Black fog
+            // worldSphere.radius and worldSphere.center are already defined and used above for camera calculations.
+            // distance is also defined above as the camera's distance from worldSphere.center.z
+            // We need distanceToModelCenter which is the direct distance from camera to sphere center.
+            const distanceToModelCenter = camera.position.distanceTo(worldSphere.center);
+            const modelRadius = worldSphere.radius;
+
+            const fogNear = Math.max(0.1, distanceToModelCenter - modelRadius * 1.2); // Start fog slightly before hitting the center, or just behind front face
+            const fogFar = distanceToModelCenter + modelRadius * 4;    // Fully fogged a few model radii behind
+
+            scene.fog = new THREE.Fog(fogColor, fogNear, fogFar);
+            console.log(`Fog added: near ${fogNear.toFixed(2)}, far ${fogFar.toFixed(2)}`);
         },
         (xhr) => {
             // console.log((xhr.loaded / xhr.total * 100) + '% loaded');


### PR DESCRIPTION
This commit introduces fog to the three.js scene.

Key changes in `script.js`:
- Added `scene.fog = new THREE.Fog(...)` in the `gltfLoader.load` callback.
- Fog color is black (0x000000) to match the background.
- Fog `near` and `far` distances are calculated dynamically based on:
    - The loaded model's bounding sphere radius (`modelRadius`).
    - The distance from the camera to the model's center (`distanceToModelCenter`).
- `fogNear` is set Verhalten `distanceToModelCenter - modelRadius * 1.2` (clamped at 0.1).
- `fogFar` is set to `distanceToModelCenter + modelRadius * 4`. This ensures the fog effect is appropriately scaled to the scene and model size after camera adjustments.