### PR TITLE
Fix: Adjust camera distance to reduce on-screen model size

### DIFF
--- a/script.js
+++ b/script.js
@@ -112,9 +112,14 @@ function init() {
         const center = boundingBox.getCenter(new THREE.Vector3());
         const size = boundingBox.getSize(new THREE.Vector3());
         const maxDim = Math.max(size.x, size.y, size.z);
-        const fov = camera.fov * (Math.PI / 180);
-        let cameraZ = Math.abs(maxDim / 2 * Math.tan(fov * 2)); // Basic calculation
-        cameraZ *= 1.5; // Zoom out a bit
+        const fov = camera.fov * (Math.PI / 180); // Convert vertical FOV to radians
+
+        // Calculate distance to fit object perfectly based on FOV and object's largest dimension
+        // The /2 is because tan(fov/2) relates half the dimension to the distance.
+        let cameraZ = maxDim / 2 / Math.tan(fov / 2);
+        
+        cameraZ *= 2.5; // Zoom out further by applying the new multiplier
+
         camera.position.set(center.x, center.y, center.z + cameraZ);
         camera.lookAt(center);
         console.log('Camera position adjusted for model 1.');


### PR DESCRIPTION
The 3D models were appearing too large in your viewport. This commit addresses the issue by modifying the camera setup logic within the `onLoadedCallback` for the first loaded model in `script.js`.

Changes include:
- Corrected the base formula for calculating `cameraZ` (the camera's distance along the Z-axis from the model) to use the standard perspective camera distance formula: `cameraZ = (maxDim / 2) / Math.tan(fov / 2);`
- Increased the multiplier for `cameraZ` from `1.5` to `2.5`. This pushes the camera further away from the models, making them appear smaller and more comfortably viewable.

The normalization of models in `loadGLTFModel` ensures that this camera setup, though based on the first model, should be appropriate for the second model as well.