### PR TITLE
feat: Add boosted spin during scale-up reorientation

### DIFF
--- a/script.js
+++ b/script.js
@@ -457,9 +457,21 @@ function animateModel(modelData, deltaTime, elapsedTimeTotal) {
         if (animElapsedTime < animationConfig.SCALE_DURATION) {
             const scaleProgress = animElapsedTime / animationConfig.SCALE_DURATION; // Progress from 0 to 1
 
-            const targetQuaternion = new THREE.Quaternion(); // Identity quaternion (0,0,0 rotation)
-            if (modelData.initialQuaternionDuringScaleUp) {
-                modelData.gltfModel.quaternion.copy(modelData.initialQuaternionDuringScaleUp).slerp(targetQuaternion, scaleProgress);
+            // Calculate slerped orientation
+            const slerpTargetQuaternion = new THREE.Quaternion(); // Target world orientation (0,0,0)
+            if (modelData.initialQuaternionDuringScaleUp) { // Ensure initialQuaternion is available
+                modelData.gltfModel.quaternion.copy(modelData.initialQuaternionDuringScaleUp).slerp(slerpTargetQuaternion, scaleProgress);
+            } else {
+                // Fallback if initialQuaternionDuringScaleUp was somehow not set (should not happen with current logic)
+                modelData.gltfModel.quaternion.slerp(slerpTargetQuaternion, scaleProgress);
+            }
+
+            // Apply additional local Y-axis boosted spin
+            if (modelData.isRotationBoostActive && elapsedTimeTotal < modelData.boostEndTime) {
+                const boostSpinAmount = (animationConfig.NORMAL_ROTATION_SPEED * animationConfig.BOOST_ROTATION_MULTIPLIER) * deltaTime;
+                modelData.gltfModel.rotateY(boostSpinAmount); // Rotates around the object's local Y-axis
+            } else if (modelData.isRotationBoostActive) {
+                modelData.isRotationBoostActive = false; // Boost time ended
             }
             // Scale factor from 0 up to 1 (based on initialScale)
             modelData.gltfModel.scale.set(
@@ -473,6 +485,7 @@ function animateModel(modelData, deltaTime, elapsedTimeTotal) {
             modelData.isScalingUp = false; // Reset flag
             modelData.gltfModel.rotation.set(0, 0, 0); // Set final rotation to (0,0,0)
             modelData.initialQuaternionDuringScaleUp = null; // Reset for next use
+            modelData.isRotationBoostActive = false; // Ensure boost is off
 
             // Post-scaling up: Update active model identifier and set appropriate light intensities
             // This is now handled by the state machine in the main animate() function upon transitioning to IDLE states.


### PR DESCRIPTION
This commit updates the model animation behavior based on your refined requirements.

During the scale-up phase, models now perform two simultaneous rotations:
1. They slerp their overall orientation towards (0,0,0) world rotation (to face the camera).
2. Concurrently, they spin around their local Y-axis at the boosted rotation speed.

This combined effect creates a dynamic "spinning while turning" animation as the models scale into view.

Once the scale-up and re-orientation are complete, the model's rotation is set precisely to (0,0,0), and it then resumes its normal idle Y-axis rotation. The `isRotationBoostActive` flag and `boostEndTime` are managed to ensure the boosted spin is correctly applied only during the scale-up period.