### PR TITLE
chore: Update glTF model for model 1

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,7 +10,7 @@ const clock = new THREE.Clock();
 // Holds all data related to the first 3D model
 const model1Data = {
     gltfModel: null, // The Three.js object for the model
-    modelUrl: 'https://raw.githubusercontent.com/RSOS-ops/CoryPill-2/main/ShadowedGaze-good-1.glb', // URL to load the GLB/GLTF file
+    modelUrl: 'https://raw.githubusercontent.com/RSOS-ops/CoryPill-2/main/HoodedCory_Planar3.glb', // URL to load the GLB/GLTF file
     initialScale: new THREE.Vector3(1, 1, 1), // Initial scale after normalization
     initialQuaternionDuringScaleUp: null,
     isRotationBoostActive: false, // Flag for rotation speed boost


### PR DESCRIPTION
Replaces the existing glTF model for the first object (`model1Data`) with a new model located at:
https://raw.githubusercontent.com/RSOS-ops/CoryPill-2/main/HoodedCory_Planar3.glb

All existing animations and functionalities will apply to this new model.